### PR TITLE
Fix RtMidi wheel build on Python 3.10 nightly in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
 install:
   - >
     if [ "$TRAVIS_PYTHON_VERSION" == "nightly" ]; then
+      pip install Cython ;
       pip download python-rtmidi ;
       tar xvf python-rtmidi-*.tar.gz ;
       rm python-rtmidi-*.tar.gz ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,15 @@ python:
                # enabled now
                # to troubleshoot https://github.com/SpotlightKid/python-rtmidi/issues/68
 install:
+  - >
+    if [ "$TRAVIS_PYTHON_VERSION" == "nightly" ]; then
+      pip download python-rtmidi ;
+      tar xvf python-rtmidi-*.tar.gz ;
+      rm python-rtmidi-*.tar.gz ;
+      cd python-rtmidi-* ;
+      make clean-build ;
+      python setup.py install ;
+      cd .. ;
+    fi
   - pip install -e '.[test]'
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
       make clean-build ;
       python setup.py install ;
       cd .. ;
+      rm -rf python-rtmidi-* ;
     fi
   - pip install -e '.[test]'
 script: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["Cython", "setuptools", "wheel"]  # PEP 508 specifications + Cython.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.
 
 [tool.black]
 skip-string-normalization = true


### PR DESCRIPTION
Re-cythonization seems to be needed on Python nightly.